### PR TITLE
Fix to _signatures script

### DIFF
--- a/Cellula/dist_features/_signatures.py
+++ b/Cellula/dist_features/_signatures.py
@@ -4,7 +4,8 @@ _signatures.py stores functions and utilities for scoring a Gene_set or a list o
 
 import os
 import pandas as pd 
-import numpy as np 
+import numpy as np
+import sys
 from random import seed, sample
 from scipy.sparse import csr_matrix, csc_matrix, issparse 
 from collections import Counter 
@@ -282,9 +283,18 @@ def format_curated(path_main):
     for x in os.listdir(path_main + 'data/curated_signatures/'):
         name = x.split('.')[0]
         if x != '.DS_Store':
-            genes = pd.read_csv(
-                path_main + f'data/curated_signatures/{x}', sep='\t', index_col=0
-            ).iloc[:, 0].to_list()
-            curated[name] = genes
+            try:
+               genes = pd.read_csv(path_main + f'data/curated_signatures/{x}', sep='\t', index_col=0).iloc[:, 0].to_list()
+               curated[name] = genes
+            except:
+               try:
+                   genes = pd.read_csv(path_main + f'data/curated_signatures/{x}', sep=',', index_col=0).iloc[:, 0].to_list()
+                   curated[name] = genes
+               except:
+                 sys.exit("Error: the following .txt file is not correctly formatted with 'tab' or ',' separators " + path_main + f'data/curated_signatures/{x}')
+            
+            for i in genes:
+                if type(i) is float:
+                    sys.exit("Error: the following .txt file has mixed separators "+ path_main + f'data/curated_signatures/{x}')
 
     return curated


### PR DESCRIPTION
Changed the format_curated function in _signatures.py script to allow reading of .csv or .tsv files and in case of different or mixed formats  interrupt the pipeline.